### PR TITLE
Reorganize demographic attributes as individual entities

### DIFF
--- a/app/controllers/api/demographics_controller.rb
+++ b/app/controllers/api/demographics_controller.rb
@@ -1,6 +1,6 @@
 class Api::DemographicsController < ApplicationController
-  skip_before_action :authenticate
-  def categories
+
+  def new
     genders = Gender.all
     countries = Country.all
     races = Race.all
@@ -15,6 +15,6 @@ class Api::DemographicsController < ApplicationController
                   sex_ors: sex_ors,
                   seses: seses
     }
-
   end
+
 end

--- a/app/controllers/api/demographics_controller.rb
+++ b/app/controllers/api/demographics_controller.rb
@@ -1,2 +1,20 @@
-class Api::DemographicController < ApplicationController
+class Api::DemographicsController < ApplicationController
+  skip_before_action :authenticate
+  def categories
+    genders = Gender.all
+    countries = Country.all
+    races = Race.all
+    religions = Religion.all
+    sex_ors = SexOr.all
+    seses = Ses.all
+    render json: {
+                  genders: genders,
+                  countries: countries,
+                  races: races,
+                  religions: religions,
+                  sex_ors: sex_ors,
+                  seses: seses
+    }
+
+  end
 end

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -1,0 +1,3 @@
+class Country < ActiveRecord::Base
+  has_many :demographics
+end

--- a/app/models/demographic.rb
+++ b/app/models/demographic.rb
@@ -1,3 +1,9 @@
 class Demographic < ActiveRecord::Base
-  belongs_to :user
+  has_one :user
+  belongs_to :gender
+  belongs_to :race
+  belongs_to :sex_or
+  belongs_to :country
+  belongs_to :religion
+  belongs_to :ses
 end

--- a/app/models/gender.rb
+++ b/app/models/gender.rb
@@ -1,0 +1,3 @@
+class Gender < ActiveRecord::Base
+  has_many :demographics
+end

--- a/app/models/race.rb
+++ b/app/models/race.rb
@@ -1,0 +1,3 @@
+class Race < ActiveRecord::Base
+  has_many :demographics
+end

--- a/app/models/religion.rb
+++ b/app/models/religion.rb
@@ -1,0 +1,3 @@
+class Religion < ActiveRecord::Base
+  has_many :demographics
+end

--- a/app/models/ses.rb
+++ b/app/models/ses.rb
@@ -1,0 +1,3 @@
+class Ses < ActiveRecord::Base
+  has_many  :demographics
+end

--- a/app/models/sex_or.rb
+++ b/app/models/sex_or.rb
@@ -1,0 +1,3 @@
+class SexOr < ActiveRecord::Base
+  has_many  :demographics
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,12 @@ class User < ActiveRecord::Base
   has_secure_password
 
   has_one :demographic
+  has_one :gender, through: :demographic
+  has_one :race, through: :demographic
+  has_one :sex_or, through: :demographic
+  has_one :country, through: :demographic
+  has_one :religion, through: :demographic
+  has_one :ses, through: :demographic
   has_many :user_interests
   has_many :interests, through: :user_interests
   has_many :first_user_matches, foreign_key: "first_user_id", class_name: "Match"
@@ -9,6 +15,10 @@ class User < ActiveRecord::Base
 
 validates :first_name, :last_name, :password_digest, presence: true
 validates :email, presence: true, uniqueness: true
+
+def age
+  self.demographic.age
+end
 
 end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
     get 'users/profile'
     patch 'users/profile' => "users#edit_profile", as: 'edit_profile'
     get 'users/:id/interests' => "users#interests", as: 'user_interests'
+    get 'demographics/categories' => 'demographics#categories', as: 'demographics_categories'
 
     resources :users
     resources :interests

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,8 +5,8 @@ Rails.application.routes.draw do
     get 'users/profile'
     patch 'users/profile' => "users#edit_profile", as: 'edit_profile'
     get 'users/:id/interests' => "users#interests", as: 'user_interests'
-    get 'demographics/categories' => 'demographics#categories', as: 'demographics_categories'
 
+    resources :demographics
     resources :users
     resources :interests
     resources :matches do

--- a/db/migrate/20160316001549_remove_infocolumns_from_demographics.rb
+++ b/db/migrate/20160316001549_remove_infocolumns_from_demographics.rb
@@ -1,0 +1,16 @@
+class RemoveInfocolumnsFromDemographics < ActiveRecord::Migration
+  def change
+    remove_column :demographics, :gender
+    remove_column :demographics, :race
+    remove_column :demographics, :sex_or
+    remove_column :demographics, :country
+    remove_column :demographics, :religion
+    remove_column :demographics, :ses
+    add_column :demographics, :gender_id, :integer
+    add_column :demographics, :race_id, :integer
+    add_column :demographics, :sex_or_id, :integer
+    add_column :demographics, :country_id, :integer
+    add_column :demographics, :religion_id, :integer
+    add_column :demographics, :ses_id, :integer
+  end
+end

--- a/db/migrate/20160316002956_create_genders.rb
+++ b/db/migrate/20160316002956_create_genders.rb
@@ -1,0 +1,7 @@
+class CreateGenders < ActiveRecord::Migration
+  def change
+    create_table :genders do |t|
+      t.string :name
+    end
+  end
+end

--- a/db/migrate/20160316003002_create_races.rb
+++ b/db/migrate/20160316003002_create_races.rb
@@ -1,0 +1,7 @@
+class CreateRaces < ActiveRecord::Migration
+  def change
+    create_table :races do |t|
+      t.string :name
+    end
+  end
+end

--- a/db/migrate/20160316003020_create_sex_ors.rb
+++ b/db/migrate/20160316003020_create_sex_ors.rb
@@ -1,0 +1,7 @@
+class CreateSexOrs < ActiveRecord::Migration
+  def change
+    create_table :sex_ors do |t|
+      t.string :name
+    end
+  end
+end

--- a/db/migrate/20160316003036_create_countries.rb
+++ b/db/migrate/20160316003036_create_countries.rb
@@ -1,0 +1,7 @@
+class CreateCountries < ActiveRecord::Migration
+  def change
+    create_table :countries do |t|
+      t.string :name
+    end
+  end
+end

--- a/db/migrate/20160316003045_create_religions.rb
+++ b/db/migrate/20160316003045_create_religions.rb
@@ -1,0 +1,7 @@
+class CreateReligions < ActiveRecord::Migration
+  def change
+    create_table :religions do |t|
+      t.string :name
+    end
+  end
+end

--- a/db/migrate/20160316003102_create_ses.rb
+++ b/db/migrate/20160316003102_create_ses.rb
@@ -1,0 +1,7 @@
+class CreateSes < ActiveRecord::Migration
+  def change
+    create_table :ses do |t|
+      t.string :name
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,22 +11,30 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160315223236) do
+ActiveRecord::Schema.define(version: 20160316003102) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
+  create_table "countries", force: :cascade do |t|
+    t.string "name"
+  end
+
   create_table "demographics", force: :cascade do |t|
     t.integer  "age"
-    t.string   "gender"
-    t.string   "race"
-    t.string   "sex_or"
-    t.string   "country"
-    t.string   "religion"
-    t.string   "ses"
     t.integer  "user_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
+    t.integer  "gender_id"
+    t.integer  "race_id"
+    t.integer  "sex_or_id"
+    t.integer  "country_id"
+    t.integer  "religion_id"
+    t.integer  "ses_id"
+  end
+
+  create_table "genders", force: :cascade do |t|
+    t.string "name"
   end
 
   create_table "interests", force: :cascade do |t|
@@ -58,6 +66,22 @@ ActiveRecord::Schema.define(version: 20160315223236) do
     t.string   "text"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "races", force: :cascade do |t|
+    t.string "name"
+  end
+
+  create_table "religions", force: :cascade do |t|
+    t.string "name"
+  end
+
+  create_table "ses", force: :cascade do |t|
+    t.string "name"
+  end
+
+  create_table "sex_ors", force: :cascade do |t|
+    t.string "name"
   end
 
   create_table "topics", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,13 +6,15 @@
 #   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
 #   Mayor.create(name: 'Emanuel', city: cities.first)
 
-race = ["White", "Black", "Native American", "Latino/Hispanic", "Asian", "Pacific Islander", "Middle Eastern"]
+races = ["White", "Black", "Native American", "Latino/Hispanic", "Asian", "Pacific Islander", "Middle Eastern"]
 
 religions = ["Catholicism", "Christiany", "Judaism", "Islam", "Atheism", "Buddhism", "Shintoism", "Hinduism", "Taoism", "Maori", "Wiccan"]
 
 sex_ors = ["Heterosexual", "Gay/Lesbian", "Queer", "Bisexual", "Transgender", "Asexual"]
 
-ses = ["Upper-SES", "Middle-SES", "Low-SES"]
+genders = ["Female", "Non-binary/Other", "Male"]
+
+seses = ["Upper-SES", "Middle-SES", "Low-SES"]
 
 countries = ["US", "Mexico", "Canada", "England", "Russia", "Turkey", "Ethiopia", "France", "Germany", "Brazil", "South Africa", "India", "Iran", "Romania", "Ireland", "Scotland", "Sweden", "Chile", "Argentina", "Kuwait", "Saudi Arabia", "Jordan", "China", "Japan", "Denmark", "Cambodia", "Afghanistan", "Mongolia", "Lithuania", "Czech Republic", "Cuba", "Australia", "New Zealand"]
 
@@ -25,6 +27,43 @@ Message.delete_all
 Interest.delete_all
 Topic.delete_all
 UserInterest.delete_all
+Race.delete_all
+Country.delete_all
+Gender.delete_all
+Ses.delete_all
+SexOr.delete_all
+Religion.delete_all
+
+races.each do |race|
+  Race.create([name: race])
+end
+
+countries.each do |country|
+  Country.create([name: country])
+end
+
+genders.each do |gender|
+  Gender.create([name: gender])
+end
+
+religions.each do |religion|
+  Religion.create([name: religion])
+end
+
+sex_ors.each do |sex_or|
+  SexOr.create([name: sex_or])
+end
+
+seses.each do |ses|
+  Ses.create([name: ses])
+end
+
+gender_objs = Gender.all
+race_objs = Race.all
+sex_or_objs = SexOr.all
+country_objs = Country.all
+religion_objs = Religion.all
+ses_objs = Ses.all
 
 20.times do
   users = User.create([first_name: Faker::Name.first_name,
@@ -36,12 +75,12 @@ end
 
 User.all.each do |user|
   demographics = Demographic.create([age: rand(18..80),
-                                     gender: ["male", "female", "other"].sample,
-                                     race: race.sample,
-                                     sex_or: sex_ors.sample,
-                                     country: countries.sample,
-                                     religion: religions.sample,
-                                     ses: ses.sample,
+                                     gender_id: gender_objs.sample.id,
+                                     race_id: race_objs.sample.id,
+                                     sex_or_id: sex_or_objs.sample.id,
+                                     country_id: country_objs.sample.id,
+                                     religion_id: religion_objs.sample.id,
+                                     ses_id: ses_objs.sample.id,
                                      user_id: user.id])
 end
 

--- a/spec/controllers/api/demographic_controller_spec.rb
+++ b/spec/controllers/api/demographic_controller_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe DemographicController, type: :controller do
-
-end

--- a/spec/controllers/api/demographics_controller_spec.rb
+++ b/spec/controllers/api/demographics_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Api::DemographicsController, type: :controller do
+
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -50,22 +50,6 @@ describe User do
     expect(user.errors[:password_digest]).to include("can't be blank")
   end
 
-  it "is invalid without a unique password" do
-    User.create(
-      first_name: 'Cloud',
-      last_name: 'Strife',
-      email: 'fatsword@midgar.com',
-      password_digest: 'password')
-
-    user = User.new(
-      first_name: 'Tifa',
-      last_name: 'Lockhart',
-      email: 'punchgloves@midgar.com',
-      password_digest: 'password')
-    user.valid?
-    expect(user.errors[:password_digest]).to include("has already been taken")
-  end
-
   it "is invalid without a unique email" do
     User.create(
       first_name: 'Cloud',


### PR DESCRIPTION
**Summary**
I reorganized the fields under the demographics table as individual entities. This will allow us to serve pre-seeded values for each demographic attribute on the front end and users can simply choose the demographics that they identify with. Then their demographic sheet will simply have a reference to the ID of the respective value for each attribute.
